### PR TITLE
Add profile images and status to leads

### DIFF
--- a/channel_portal.sql
+++ b/channel_portal.sql
@@ -76,6 +76,8 @@ CREATE TABLE `leads` (
   `phone` varchar(20) DEFAULT NULL,
   `property_id` int(11) DEFAULT NULL,
   `message` text,
+  `avatar` varchar(255) DEFAULT NULL,
+  `status` varchar(20) DEFAULT 'Pending',
   `created_at` timestamp NOT NULL DEFAULT current_timestamp()
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 

--- a/index.php
+++ b/index.php
@@ -9,7 +9,7 @@ $totalUsers = $conn->query("SELECT COUNT(*) AS c FROM users")->fetch_assoc()['c'
 $todayLeads = $conn->query("SELECT COUNT(*) AS c FROM leads WHERE DATE(created_at)=CURDATE()")->fetch_assoc()['c'];
 
 $recentProperties = $conn->query("SELECT id, project_name, location, starting_price FROM properties ORDER BY created_at DESC LIMIT 5");
-$recentLeads = $conn->query("SELECT leads.name, leads.email, properties.project_name, leads.created_at FROM leads LEFT JOIN properties ON leads.property_id = properties.id ORDER BY leads.created_at DESC LIMIT 5");
+$recentLeads = $conn->query("SELECT leads.id, leads.name, leads.email, leads.avatar, leads.status, properties.project_name, leads.created_at FROM leads LEFT JOIN properties ON leads.property_id = properties.id ORDER BY leads.created_at DESC LIMIT 5");
 ?>
 
 <?php include 'includes/common-header.php'; ?>
@@ -406,11 +406,9 @@ $recentLeads = $conn->query("SELECT leads.name, leads.email, properties.project_
 
                                                     <?php while ($l = $recentLeads->fetch_assoc()): ?>
                                                         <tr>
+                                                            <td>#<?php echo htmlspecialchars($l['id']); ?></td>
                                                             <td>
-                                                                #VZ2112
-                                                            </td>
-                                                            <td>
-                                                                <div class="d-flex align-items-center">
+                                                               <div class="d-flex align-items-center">
                                                                     <div class="flex-shrink-0 me-2">
                                                                         <?php if (isset($l['avatar']) && !empty($l['avatar'])): ?>
                                                                             <img src="<?php echo htmlspecialchars($l['avatar']); ?>" alt=""


### PR DESCRIPTION
## Summary
- support avatar uploads and status values when creating leads
- display lead IDs, avatars, and statuses on leads page and dashboard recent leads
- update database schema for new avatar and status fields

## Testing
- `php -l leads.php`
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68b828774c14832aafe0c059086f62db