### PR TITLE
Fix missing currency symbol on non-AED views

### DIFF
--- a/includes/common-footer.php
+++ b/includes/common-footer.php
@@ -219,15 +219,19 @@
             });
         }
 
+        // Always show the currency symbol even if the exchange-rate fetch fails.
+        applyConversion(1);
+
         if (selectedCurrency !== baseCurrency) {
             fetch(`https://api.exchangerate.host/latest?base=${baseCurrency}`)
                 .then(res => res.json())
                 .then(data => {
                     const rate = data.rates[selectedCurrency] || 1;
                     applyConversion(rate);
+                })
+                .catch(() => {
+                    // If the API request fails, we keep the base amount but the symbol remains visible.
                 });
-        } else {
-            applyConversion(1);
         }
     })();
 </script>


### PR DESCRIPTION
## Summary
- always render currency symbols on property prices
- gracefully handle exchange rate API failures

## Testing
- `php -l includes/common-footer.php`
- `php -l index.php all-properties.php`


------
https://chatgpt.com/codex/tasks/task_e_68b931f2987c832ab9705d701b8eda91