### PR TITLE
Update lead statuses and add lead management actions

### DIFF
--- a/index.php
+++ b/index.php
@@ -437,19 +437,20 @@ if ($projectLocations) {
                                                                 <td>
                                                                     <?php
                                                                     $statusClass = '';
-                                                                    $statusText = isset($l['status']) ? $l['status'] : 'Pending';
+                                                                    $statusText = isset($l['status']) ? $l['status'] : 'Interested';
 
                                                                     switch (strtolower($statusText)) {
-                                                                        case 'completed':
-                                                                        case 'active':
+                                                                        case 'interested':
                                                                             $statusClass = 'bg-success-subtle text-success';
                                                                             break;
-                                                                        case 'pending':
-                                                                            $statusClass = 'bg-warning-subtle text-warning';
-                                                                            break;
-                                                                        case 'cancelled':
-                                                                        case 'rejected':
+                                                                        case 'not interested':
                                                                             $statusClass = 'bg-danger-subtle text-danger';
+                                                                            break;
+                                                                        case 'cold':
+                                                                            $statusClass = 'bg-info-subtle text-info';
+                                                                            break;
+                                                                        case 'hot':
+                                                                            $statusClass = 'bg-warning-subtle text-warning';
                                                                             break;
                                                                         default:
                                                                             $statusClass = 'bg-info-subtle text-info';


### PR DESCRIPTION
## Summary
- replace old lead status labels with Interested, Not Interested, Cold, and Hot across dashboard and lead manager
- support editing and deleting leads with new actions and modal-based form

## Testing
- `php -l leads.php`
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68b937dbe53c832a8f43626775a12193