### PR TITLE
Enable brochure download on property details

### DIFF
--- a/property-details.php
+++ b/property-details.php
@@ -60,10 +60,12 @@ $heroImage = !empty($property['main_picture'])
                     </div>
                     <div class="col-12 mt-3">
                         <div class="d-flex justify-content-center gap-3 flex-wrap">
-                            <a href="#" class="btn-custom">
-                                Download Brochure
-                                <i class="bi bi-download"></i>
-                            </a>
+                            <?php if (!empty($property['brochure'])): ?>
+                                <a href="uploads/<?= htmlspecialchars($property['brochure']); ?>" class="btn-custom" download>
+                                    Download Brochure
+                                    <i class="bi bi-download"></i>
+                                </a>
+                            <?php endif; ?>
                             <a href="leads.php" class="btn-custom">
                                 Enquire Now
                                 <i class="bi bi-arrow-right"></i>


### PR DESCRIPTION
## Summary
- Link Download Brochure button directly to uploaded brochure file with forced download

## Testing
- `php -l property-details.php`

------
https://chatgpt.com/codex/tasks/task_e_68b93c8064a4832a87a3e7fce944ad43