### PR TITLE
feat: enable multi-image gallery

### DIFF
--- a/add-property.php
+++ b/add-property.php
@@ -118,7 +118,7 @@
                                 ondrop="handleDrop(event, 'main_picture')">
                                 <div class="icon"><img width="40" src="assets/icons/upload-images.png" alt=""></div>
                                 <p>Drop files here or click to upload</p>
-                                <input type="file" id="main_picture" name="main_picture" onchange="showFileName(this)">
+                                <input type="file" id="main_picture" name="main_picture[]" multiple onchange="showFileName(this)">
                             </div>
                             <div id="file-name-main_picture" class="file-name"></div>
 

--- a/add_property.php
+++ b/add_property.php
@@ -87,7 +87,7 @@
                 ondrop="handleDrop(event, 'main_picture')">
                 <div class="icon"><img width="40" src="assets/icons/upload-images.png" alt=""></div>
                 <p>Drop files here or click to upload</p>
-                <input type="file" id="main_picture" name="main_picture" required onchange="showFileName(this)">
+                <input type="file" id="main_picture" name="main_picture[]" multiple required onchange="showFileName(this)">
             </div>
             <div id="file-name-main_picture" class="file-name"></div>
             <div class="error-msg">Please upload main picture</div>

--- a/all-properties.php
+++ b/all-properties.php
@@ -122,8 +122,14 @@ $result = $stmt->get_result();
                                 <div class="propertiesList">
                                     <div class="property-card">
                                         <a href="property-details.php?id=<?= $property['id']; ?>" class="">
-                                            <?php if (!empty($property['main_picture'])): ?>
-                                                <img src="uploads/<?= $property['main_picture']; ?>" alt="Main Picture" class="img-fluid w-100">
+                                            <?php
+                                            $mainImage = '';
+                                            if (!empty($property['main_picture'])) {
+                                                $parts = array_map('trim', explode(',', $property['main_picture']));
+                                                $mainImage = $parts[0];
+                                            }
+                                            if (!empty($mainImage)): ?>
+                                                <img src="uploads/<?= $mainImage; ?>" alt="Main Picture" class="img-fluid w-100">
                                             <?php else: ?>
                                                 <img src="assets/images/offplan/default.png" alt="No Image" class="img-fluid w-100">
                                             <?php endif; ?>

--- a/includes/common-footer.php
+++ b/includes/common-footer.php
@@ -177,8 +177,8 @@
 
     <script>
     function showFileName(input) {
-        const fileName = input.files[0] ? input.files[0].name : '';
-        document.getElementById('file-name-' + input.id).textContent = fileName;
+        const names = Array.from(input.files).map(file => file.name).join(', ');
+        document.getElementById('file-name-' + input.id).textContent = names;
     }
 
     function handleDragOver(event) {

--- a/index.php
+++ b/index.php
@@ -350,7 +350,14 @@ if ($projectLocations) {
                                                     <div class="col-sm-6 col-lg-4 col-xl-3">
                                                         <a href="property-details.php?id=<?= $p['id']; ?>" class="text-decoration-none text-dark">
                                                             <div class="card h-100">
-                                                                <img src="<?= !empty($p['main_picture']) ? 'uploads/' . $p['main_picture'] : 'assets/images/offplan/default.png'; ?>"
+                                                                <?php
+                                                                $mainImage = '';
+                                                                if (!empty($p['main_picture'])) {
+                                                                    $parts = array_map('trim', explode(',', $p['main_picture']));
+                                                                    $mainImage = $parts[0];
+                                                                }
+                                                                ?>
+                                                                <img src="<?= !empty($mainImage) ? 'uploads/' . $mainImage : 'assets/images/offplan/default.png'; ?>"
                                                                     class="card-img-top"
                                                                     alt="<?= htmlspecialchars($p['project_name']); ?>">
                                                                 <div class="card-body">

--- a/property-details.php
+++ b/property-details.php
@@ -28,9 +28,16 @@ if (!$property) {
     exit;
 }
 
-$heroImage = !empty($property['main_picture'])
-    ? 'uploads/' . $property['main_picture']
+$mainImages = !empty($property['main_picture']) ? array_map('trim', explode(',', $property['main_picture'])) : [];
+$heroImage = !empty($mainImages)
+    ? 'uploads/' . $mainImages[0]
     : 'assets/images/banner/hero-banner.webp';
+$galleryImages = $mainImages;
+foreach (['image2', 'image3', 'image4'] as $imgField) {
+    if (!empty($property[$imgField])) {
+        $galleryImages[] = $property[$imgField];
+    }
+}
 ?>
 
 <div class="main-content">
@@ -116,27 +123,16 @@ $heroImage = !empty($property['main_picture'])
         <!-- Gallery Section -->
         <section class="property-gallery-section">
             <div class="container-fluid">
-                <div class="row">
-                    <div class="col-12 col-lg-8 position-relative p-0">
-                        <?php if (!empty($property['main_picture'])): ?>
-                            <img src="uploads/<?= $property['main_picture']; ?>" alt="Main Picture"
-                                class="img-fluid w-100 h-100">
-                        <?php endif; ?>
-                    </div>
-                    <div class="col-12 col-lg-4 p-0">
-                        <div class="row">
-                            <div class="col-12">
-                                <?php if (!empty($property['image2'])): ?>
-                                    <img src="uploads/<?= $property['image2']; ?>" alt="Image 2" class="img-fluid w-100">
-                                <?php endif; ?>
+                <div class="swiper property-gallery-swiper">
+                    <div class="swiper-wrapper">
+                        <?php foreach ($galleryImages as $img): ?>
+                            <div class="swiper-slide">
+                                <img src="uploads/<?= htmlspecialchars($img); ?>" alt="Property Image" class="img-fluid w-100">
                             </div>
-                            <div class="col-12">
-                                <?php if (!empty($property['image3'])): ?>
-                                    <img src="uploads/<?= $property['image3']; ?>" alt="Image 3" class="img-fluid w-100">
-                                <?php endif; ?>
-                            </div>
-                        </div>
+                        <?php endforeach; ?>
                     </div>
+                    <div class="swiper-button-next property-gallery-next"></div>
+                    <div class="swiper-button-prev property-gallery-prev"></div>
                 </div>
             </div>
         </section>
@@ -452,3 +448,14 @@ $heroImage = !empty($property['main_picture'])
 </div>
 
 <?php include 'includes/common-footer.php'; ?>
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+        new Swiper('.property-gallery-swiper', {
+            loop: true,
+            navigation: {
+                nextEl: '.property-gallery-next',
+                prevEl: '.property-gallery-prev',
+            },
+        });
+    });
+</script>

--- a/save_property.php
+++ b/save_property.php
@@ -17,6 +17,26 @@ function uploadFile($fileInput, $folder = "uploads/")
     return null;
 }
 
+function uploadMultipleFiles($fileInput, $folder = "uploads/")
+{
+    $uploaded = [];
+    if (!empty($_FILES[$fileInput]['name'][0])) {
+        if (!is_dir($folder)) {
+            mkdir($folder, 0777, true);
+        }
+        foreach ($_FILES[$fileInput]['name'] as $key => $name) {
+            if ($_FILES[$fileInput]['error'][$key] === 0) {
+                $filename = time() . "_" . $key . "_" . basename($name);
+                $targetPath = $folder . $filename;
+                if (move_uploaded_file($_FILES[$fileInput]['tmp_name'][$key], $targetPath)) {
+                    $uploaded[] = $filename;
+                }
+            }
+        }
+    }
+    return !empty($uploaded) ? implode(',', $uploaded) : null;
+}
+
 // Collect form data
 $project_name = $_POST['project_name'] ?? '';
 $description = $_POST['description'] ?? '';
@@ -41,7 +61,7 @@ $amenities = isset($_POST['amenities']) ? implode(", ", $_POST['amenities']) : "
 
 // File uploads
 $brochure = uploadFile("brochure");
-$main_picture = uploadFile("main_picture");
+$main_picture = uploadMultipleFiles("main_picture");
 $image2 = uploadFile("image2");
 $image3 = uploadFile("image3");
 $image4 = uploadFile("image4");


### PR DESCRIPTION
## Summary
- allow multiple main images on add property form
- handle multi-image uploads and gallery display with Swiper
- show first image in property listings

## Testing
- `php -l add-property.php`
- `php -l add_property.php`
- `php -l all-properties.php`
- `php -l includes/common-footer.php`
- `php -l index.php`
- `php -l property-details.php`
- `php -l save_property.php`


------
https://chatgpt.com/codex/tasks/task_e_68b93f2ddb8c832a8e2101f435477358