### PR TITLE
Enable dynamic currency conversion

### DIFF
--- a/includes/topbar.php
+++ b/includes/topbar.php
@@ -59,14 +59,12 @@ $currencyOptions = ['AED','USD','EUR','GBP'];
 
             <div class="d-flex align-items-center">
 
-                <div class="dropdown ms-sm-3">
-                    <form method="POST" action="set_currency.php" style="width:100px">
-                        <select name="currency" class="form-select form-select-sm" onchange="this.form.submit()">
-                            <?php foreach ($currencyOptions as $code): ?>
-                                <option value="<?= $code ?>" <?= $currentCurrency === $code ? 'selected' : '' ?>><?= $code ?></option>
-                            <?php endforeach; ?>
-                        </select>
-                    </form>
+                <div class="dropdown ms-sm-3" style="width:100px">
+                    <select id="currencySwitcher" class="form-select form-select-sm">
+                        <?php foreach ($currencyOptions as $code): ?>
+                            <option value="<?= $code ?>" <?= $currentCurrency === $code ? 'selected' : '' ?>><?= $code ?></option>
+                        <?php endforeach; ?>
+                    </select>
                 </div>
 
                 <div class="dropdown ms-sm-3 header-item topbar-user">

--- a/set_currency.php
+++ b/set_currency.php
@@ -1,13 +1,17 @@
 <?php
 session_start();
+
 if (isset($_POST['currency'])) {
     $_SESSION['currency'] = $_POST['currency'];
 }
 
-$redirect = $_POST['redirect'] ?? $_SERVER['HTTP_REFERER'] ?? 'index.php';
+// If the request comes from AJAX, return a simple response
+if (!empty($_SERVER['HTTP_X_REQUESTED_WITH']) && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) === 'xmlhttprequest') {
+    echo 'ok';
+    return;
+}
 
 $redirect = $_SERVER['HTTP_REFERER'] ?? 'index.php';
-
 header('Location: ' . $redirect);
 exit;
 ?>


### PR DESCRIPTION
## Summary
- Switch topbar currency picker to a JS-driven dropdown
- Persist currency choice via AJAX and convert displayed amounts on the fly
- Update session handler to respond to AJAX without redirect

## Testing
- `php -l set_currency.php`
- `php -l includes/topbar.php`
- `php -l includes/common-footer.php`


------
https://chatgpt.com/codex/tasks/task_e_68b966f75cf4832a9574554c45c39750