### PR TITLE
feat: add dynamic currency converter for prices

### DIFF
--- a/add-property.php
+++ b/add-property.php
@@ -81,7 +81,10 @@
                         <!-- Starting Price -->
                         <div class="mb-3 col-md-6">
                             <label for="starting_price" class="form-label">Starting Price</label>
-                            <input type="number" class="form-control" id="starting_price" name="starting_price">
+                            <div class="input-group">
+                                <span class="input-group-text currency-symbol"></span>
+                                <input type="number" class="form-control" id="starting_price" name="starting_price" data-base-value="0">
+                            </div>
 
                         </div>
 
@@ -224,14 +227,19 @@
                         <!-- Starting Price (renamed) -->
                         <div class="mb-3 col-md-6">
                             <label for="floor_starting_price" class="form-label">Starting Price (Floor Plan)</label>
-                            <input type="text" class="form-control" id="floor_starting_price"
-                                name="floor_starting_price">
+                            <div class="input-group">
+                                <span class="input-group-text currency-symbol"></span>
+                                <input type="text" class="form-control" id="floor_starting_price" name="floor_starting_price" data-base-value="0">
+                            </div>
                         </div>
 
-                        <!-- AED per Sqft -->
+                        <!-- Price per Sqft -->
                         <div class="mb-3 col-md-6">
-                            <label for="aed_per_sqft" class="form-label">AED per Sqft</label>
-                            <input type="text" class="form-control" id="aed_per_sqft" name="aed_per_sqft">
+                            <label for="aed_per_sqft" class="form-label">Price per Sqft</label>
+                            <div class="input-group">
+                                <span class="input-group-text currency-symbol"></span>
+                                <input type="text" class="form-control" id="aed_per_sqft" name="aed_per_sqft" data-base-value="0">
+                            </div>
 
                         </div>
 

--- a/add_property.php
+++ b/add_property.php
@@ -50,7 +50,10 @@
         <!-- Starting Price -->
         <div class="mb-3 col-md-6">
             <label for="starting_price" class="form-label">Starting Price</label>
-            <input type="number" class="form-control" id="starting_price" name="starting_price" required>
+            <div class="input-group">
+                <span class="input-group-text currency-symbol"></span>
+                <input type="number" class="form-control" id="starting_price" name="starting_price" required data-base-value="0">
+            </div>
             <div class="error-msg">Please enter starting price</div>
         </div>
 
@@ -200,16 +203,22 @@
             <div class="error-msg">Please upload floor plan</div>
         </div>
 
-        <!-- ⚠️ Fixed: Starting Price (renamed) -->
+        <!-- Starting Price (Floor Plan) -->
         <div class="mb-3 col-md-6">
             <label for="floor_starting_price" class="form-label">Starting Price (Floor Plan)</label>
-            <input type="text" class="form-control" id="floor_starting_price" name="floor_starting_price">
+            <div class="input-group">
+                <span class="input-group-text currency-symbol"></span>
+                <input type="text" class="form-control" id="floor_starting_price" name="floor_starting_price" data-base-value="0">
+            </div>
         </div>
 
-        <!-- AED per Sqft -->
+        <!-- Price per Sqft -->
         <div class="mb-3 col-md-6">
-            <label for="aed_per_sqft" class="form-label">AED per Sqft</label>
-            <input type="text" class="form-control" id="aed_per_sqft" name="aed_per_sqft" required>
+            <label for="aed_per_sqft" class="form-label">Price per Sqft</label>
+            <div class="input-group">
+                <span class="input-group-text currency-symbol"></span>
+                <input type="text" class="form-control" id="aed_per_sqft" name="aed_per_sqft" required data-base-value="0">
+            </div>
             <div class="error-msg">Please enter AED per Sqft</div>
         </div>
 

--- a/includes/common-footer.php
+++ b/includes/common-footer.php
@@ -209,8 +209,10 @@
         const baseCurrency = 'AED';
         const currencySymbols = { AED: 'AED', USD: '$', EUR: '€', GBP: '£' };
         let currentCurrency = '<?php echo $_SESSION['currency'] ?? 'AED'; ?>';
+        let currentRate = 1;
 
         function applyConversion(rate) {
+            currentRate = rate;
             document.querySelectorAll('[data-base-amount],[data-base-value]').forEach(el => {
                 const raw = el.getAttribute('data-base-amount') || el.getAttribute('data-base-value') || '';
                 const base = parseFloat(raw.replace(/[^0-9eE.+-]/g, ''));
@@ -260,6 +262,16 @@
         }
 
         updateCurrency(currentCurrency);
+
+        // keep base values in sync when user edits converted fields
+        document.querySelectorAll('[data-base-value]').forEach(el => {
+            el.addEventListener('input', function () {
+                const val = parseFloat(this.value.replace(/[^0-9eE.+-]/g, ''));
+                if (isNaN(val)) return;
+                const base = val / currentRate;
+                this.setAttribute('data-base-value', base);
+            });
+        });
     })();
 </script>
 


### PR DESCRIPTION
## Summary
- track conversion rate and sync base amounts so currency switch reflects user edits
- make price fields currency-aware across property forms

## Testing
- `php -l add-property.php`
- `php -l add_property.php`
- `php -l includes/common-footer.php`


------
https://chatgpt.com/codex/tasks/task_e_68b97336ef98832aa037b2a7830f9e96