### PR TITLE
Enable dynamic floor plans on property pages

### DIFF
--- a/add-property.php
+++ b/add-property.php
@@ -193,27 +193,27 @@
                     <div class="row">
                         <!-- Floor Plan -->
                         <div class="mb-3 col-md-6">
-                            <label for="floor_plan" class="form-label">Floor Plan</label>
-                            <input type="file" class="form-control" id="floor_plan" name="floor_plan">
+                            <label for="floor_plan1" class="form-label">Floor Plan</label>
+                            <input type="file" class="form-control" id="floor_plan1" name="floor_plan[]">
 
                         </div>
 
                         <!-- Starting Price (renamed) -->
                         <div class="mb-3 col-md-6">
-                            <label for="floor_starting_price" class="form-label">Starting Price (Floor Plan)</label>
+                            <label for="floor_starting_price1" class="form-label">Starting Price (Floor Plan)</label>
                             <div class="input-group">
                                 <span class="input-group-text currency-symbol"></span>
-                                <input type="text" class="form-control" id="floor_starting_price"
-                                    name="floor_starting_price" data-base-value="0">
+                                <input type="text" class="form-control" id="floor_starting_price1"
+                                    name="floor_starting_price[]" data-base-value="0">
                             </div>
                         </div>
 
                         <!-- Price per Sqft -->
                         <div class="mb-3 col-md-6">
-                            <label for="aed_per_sqft" class="form-label">Price per Sqft</label>
+                            <label for="aed_per_sqft1" class="form-label">Price per Sqft</label>
                             <div class="input-group">
                                 <span class="input-group-text currency-symbol"></span>
-                                <input type="text" class="form-control" id="aed_per_sqft" name="aed_per_sqft"
+                                <input type="text" class="form-control" id="aed_per_sqft1" name="aed_per_sqft[]"
                                     data-base-value="0">
                             </div>
 
@@ -221,8 +221,8 @@
 
                         <!-- Starting Area -->
                         <div class="mb-3 col-md-6">
-                            <label for="starting_area" class="form-label">Starting Area</label>
-                            <input type="text" class="form-control" id="starting_area" name="starting_area">
+                            <label for="starting_area1" class="form-label">Starting Area</label>
+                            <input type="text" class="form-control" id="starting_area1" name="starting_area[]">
 
                         </div>
                     </div>
@@ -231,27 +231,27 @@
                     <div class="row">
                         <!-- Floor Plan -->
                         <div class="mb-3 col-md-6">
-                            <label for="floor_plan" class="form-label">Floor Plan</label>
-                            <input type="file" class="form-control" id="floor_plan" name="floor_plan">
+                            <label for="floor_plan2" class="form-label">Floor Plan</label>
+                            <input type="file" class="form-control" id="floor_plan2" name="floor_plan[]">
 
                         </div>
 
                         <!-- Starting Price (renamed) -->
                         <div class="mb-3 col-md-6">
-                            <label for="floor_starting_price" class="form-label">Starting Price (Floor Plan)</label>
+                            <label for="floor_starting_price2" class="form-label">Starting Price (Floor Plan)</label>
                             <div class="input-group">
                                 <span class="input-group-text currency-symbol"></span>
-                                <input type="text" class="form-control" id="floor_starting_price"
-                                    name="floor_starting_price" data-base-value="0">
+                                <input type="text" class="form-control" id="floor_starting_price2"
+                                    name="floor_starting_price[]" data-base-value="0">
                             </div>
                         </div>
 
                         <!-- Price per Sqft -->
                         <div class="mb-3 col-md-6">
-                            <label for="aed_per_sqft" class="form-label">Price per Sqft</label>
+                            <label for="aed_per_sqft2" class="form-label">Price per Sqft</label>
                             <div class="input-group">
                                 <span class="input-group-text currency-symbol"></span>
-                                <input type="text" class="form-control" id="aed_per_sqft" name="aed_per_sqft"
+                                <input type="text" class="form-control" id="aed_per_sqft2" name="aed_per_sqft[]"
                                     data-base-value="0">
                             </div>
 
@@ -259,8 +259,8 @@
 
                         <!-- Starting Area -->
                         <div class="mb-3 col-md-6">
-                            <label for="starting_area" class="form-label">Starting Area</label>
-                            <input type="text" class="form-control" id="starting_area" name="starting_area">
+                            <label for="starting_area2" class="form-label">Starting Area</label>
+                            <input type="text" class="form-control" id="starting_area2" name="starting_area[]">
 
                         </div>
                     </div>
@@ -269,27 +269,27 @@
                     <div class="row">
                         <!-- Floor Plan -->
                         <div class="mb-3 col-md-6">
-                            <label for="floor_plan" class="form-label">Floor Plan</label>
-                            <input type="file" class="form-control" id="floor_plan" name="floor_plan">
+                            <label for="floor_plan3" class="form-label">Floor Plan</label>
+                            <input type="file" class="form-control" id="floor_plan3" name="floor_plan[]">
 
                         </div>
 
                         <!-- Starting Price (renamed) -->
                         <div class="mb-3 col-md-6">
-                            <label for="floor_starting_price" class="form-label">Starting Price (Floor Plan)</label>
+                            <label for="floor_starting_price3" class="form-label">Starting Price (Floor Plan)</label>
                             <div class="input-group">
                                 <span class="input-group-text currency-symbol"></span>
-                                <input type="text" class="form-control" id="floor_starting_price"
-                                    name="floor_starting_price" data-base-value="0">
+                                <input type="text" class="form-control" id="floor_starting_price3"
+                                    name="floor_starting_price[]" data-base-value="0">
                             </div>
                         </div>
 
                         <!-- Price per Sqft -->
                         <div class="mb-3 col-md-6">
-                            <label for="aed_per_sqft" class="form-label">Price per Sqft</label>
+                            <label for="aed_per_sqft3" class="form-label">Price per Sqft</label>
                             <div class="input-group">
                                 <span class="input-group-text currency-symbol"></span>
-                                <input type="text" class="form-control" id="aed_per_sqft" name="aed_per_sqft"
+                                <input type="text" class="form-control" id="aed_per_sqft3" name="aed_per_sqft[]"
                                     data-base-value="0">
                             </div>
 
@@ -297,8 +297,8 @@
 
                         <!-- Starting Area -->
                         <div class="mb-3 col-md-6">
-                            <label for="starting_area" class="form-label">Starting Area</label>
-                            <input type="text" class="form-control" id="starting_area" name="starting_area">
+                            <label for="starting_area3" class="form-label">Starting Area</label>
+                            <input type="text" class="form-control" id="starting_area3" name="starting_area[]">
 
                         </div>
                     </div>

--- a/channel_portal.sql
+++ b/channel_portal.sql
@@ -44,7 +44,7 @@ CREATE TABLE `properties` (
   `image4` varchar(255) DEFAULT NULL,
   `gallery_images` text DEFAULT NULL,
   `amenities` text DEFAULT NULL,
-  `floor_plan` varchar(255) DEFAULT NULL,
+  `floor_plan` text DEFAULT NULL,
   `aed_per_sqft` varchar(50) DEFAULT NULL,
   `starting_area` varchar(50) DEFAULT NULL,
   `location` varchar(255) DEFAULT NULL,

--- a/property-details.php
+++ b/property-details.php
@@ -172,46 +172,45 @@ $heroImage = !empty($property['main_picture'])
             </div>
         </section>
 
+        <?php
+        $floorPlans = [];
+        if (!empty($property['floor_plan'])) {
+            $decoded = json_decode($property['floor_plan'], true);
+            if (is_array($decoded)) {
+                $floorPlans = $decoded;
+            } else {
+                $floorPlans[] = ['image' => $property['floor_plan']];
+            }
+        }
+        ?>
+        <?php if (!empty($floorPlans)): ?>
         <div class="floorplan-container">
 
             <!-- LEFT SECTION -->
             <div class="floorplan-left">
                 <div class="swiper mySwiper1">
                     <div class="swiper-wrapper">
-                        <!-- ---- Floor Plan 1 ----- -->
+                        <?php foreach ($floorPlans as $plan): ?>
                         <div class="swiper-slide">
-                            <img src="https://a.storyblok.com/f/165304/668x690/d73ba1d330/gardenia-bay-floor-plan.png"
-                                alt="Floorplan 1">
+                            <?php if (!empty($plan['image'])): ?>
+                            <img src="uploads/<?= htmlspecialchars($plan['image']); ?>" alt="Floorplan">
+                            <?php endif; ?>
                             <div class="floorplan-details">
-                                <div><strong><span class="currency-symbol"></span><span data-base-amount="8500000">8,500,000</span></strong> Starting price</div>
-                                <div><strong><span class="currency-symbol"></span><span data-base-amount="12108">12,108</span></strong> per ft²</div>
-                                <div><strong><span data-base-amount="702">702</span> ft²</strong> Starting area</div>
+                                <?php if (!empty($plan['starting_price'])): ?>
+                                <div><strong><span class="currency-symbol"></span><span data-base-amount="<?= htmlspecialchars($plan['starting_price']); ?>"><?= htmlspecialchars($plan['starting_price']); ?></span></strong> Starting price</div>
+                                <?php endif; ?>
+                                <?php if (!empty($plan['aed_per_sqft'])): ?>
+                                <div><strong><span class="currency-symbol"></span><span data-base-amount="<?= htmlspecialchars($plan['aed_per_sqft']); ?>"><?= htmlspecialchars($plan['aed_per_sqft']); ?></span></strong> per ft²</div>
+                                <?php endif; ?>
+                                <?php if (!empty($plan['starting_area'])): ?>
+                                <div><strong><span data-base-amount="<?= htmlspecialchars($plan['starting_area']); ?>"><?= htmlspecialchars($plan['starting_area']); ?></span> ft²</strong> Starting area</div>
+                                <?php endif; ?>
                             </div>
-                            <a href="#" class="gradient-btn btn-green-glossy mt-3">View Floor Plan</a>
+                            <?php if (!empty($plan['image'])): ?>
+                            <a href="uploads/<?= htmlspecialchars($plan['image']); ?>" class="gradient-btn btn-green-glossy mt-3" target="_blank">View Floor Plan</a>
+                            <?php endif; ?>
                         </div>
-                        <!-- ---- Floor Plan 2 ----- -->
-                        <div class="swiper-slide">
-                            <img src="https://a.storyblok.com/f/165304/996x668/1a83678dd5/gardenia-bay-floor-plan.png"
-                                alt="Floorplan 2">
-                            <div class="floorplan-details">
-                                <div><strong><span class="currency-symbol"></span><span data-base-amount="7200000">7,200,000</span></strong> Starting price</div>
-                                <div><strong><span class="currency-symbol"></span><span data-base-amount="10500">10,500</span></strong> per ft²</div>
-                                <div><strong><span data-base-amount="620">620</span> ft²</strong> Starting area</div>
-                            </div>
-                            <a href="#" class="gradient-btn btn-green-glossy mt-3">View Floor Plan</a>
-                        </div>
-
-                        <!-- ---- Floor Plan 3 ----- -->
-                        <div class="swiper-slide">
-                            <img src="https://a.storyblok.com/f/165304/1322x750/97d0d615e6/gardenia-bay-floor-plan.png"
-                                alt="Floorplan 3">
-                            <div class="floorplan-details">
-                                <div><strong><span class="currency-symbol"></span><span data-base-amount="9000000">9,000,000</span></strong> Starting price</div>
-                                <div><strong><span class="currency-symbol"></span><span data-base-amount="13000">13,000</span></strong> per ft²</div>
-                                <div><strong><span data-base-amount="780">780</span> ft²</strong> Starting area</div>
-                            </div>
-                            <a href="#" class="gradient-btn btn-green-glossy mt-3">View Floor Plan</a>
-                        </div>
+                        <?php endforeach; ?>
                     </div>
                     <!-- Swiper buttons -->
                     <div class="swiper-button-prev">&#8592;</div>
@@ -226,6 +225,7 @@ $heroImage = !empty($property['main_picture'])
                 <button class="right-btn">→</button>
             </div>
         </div>
+        <?php endif; ?>
 
         <!-- Payment Plan Section -->
         <section class="payment-plan-section d-none">

--- a/save_property.php
+++ b/save_property.php
@@ -26,8 +26,8 @@ $project_details = $_POST['project_details'] ?? '';
 $starting_price = $_POST['starting_price'] ?? '';
 $payment_plan = $_POST['payment_plan'] ?? '';
 $handover = $_POST['handover'] ?? '';
-$aed_per_sqft = $_POST['aed_per_sqft'] ?? '';
-$starting_area = $_POST['starting_area'] ?? '';
+$aed_per_sqft = $_POST['aed_per_sqft'][0] ?? '';
+$starting_area = $_POST['starting_area'][0] ?? '';
 $location = $_POST['location'] ?? '';
 $extra_text = $_POST['extra_text'] ?? '';
 $burj_al_arab = $_POST['burj_al_arab'] ?? '';
@@ -61,7 +61,27 @@ $image2 = $gallery_images[0] ?? null;
 $image3 = $gallery_images[1] ?? null;
 $image4 = $gallery_images[2] ?? null;
 $gallery_images_str = implode(",", $gallery_images);
-$floor_plan = uploadFile("floor_plan");
+$floor_plans = [];
+if (!empty($_FILES['floor_plan']['name'][0])) {
+    foreach ($_FILES['floor_plan']['name'] as $index => $name) {
+        if ($name && $_FILES['floor_plan']['error'][$index] === 0) {
+            $filename = time() . "_" . basename($name);
+            $targetPath = "uploads/" . $filename;
+            if (!is_dir("uploads/")) {
+                mkdir("uploads/", 0777, true);
+            }
+            if (move_uploaded_file($_FILES['floor_plan']['tmp_name'][$index], $targetPath)) {
+                $floor_plans[] = [
+                    'image' => $filename,
+                    'starting_price' => $_POST['floor_starting_price'][$index] ?? '',
+                    'aed_per_sqft' => $_POST['aed_per_sqft'][$index] ?? '',
+                    'starting_area' => $_POST['starting_area'][$index] ?? ''
+                ];
+            }
+        }
+    }
+}
+$floor_plan = json_encode($floor_plans);
 
 
 // Insert Query


### PR DESCRIPTION
## Summary
- allow uploading three floor plans on add property form using array inputs
- store floor plan images and metadata in JSON for each property
- render any provided floor plan images with pricing details on property details page

## Testing
- `php -l add-property.php`
- `php -l save_property.php`
- `php -l property-details.php`


------
https://chatgpt.com/codex/tasks/task_e_68b97d801d58832aba10fabbd732ac90