### PR TITLE
fix: preserve form data when editing leads

### DIFF
--- a/leads.php
+++ b/leads.php
@@ -303,13 +303,6 @@ $leads = $conn->query("SELECT leads.*, properties.project_name FROM leads LEFT J
         document.getElementById('lead-id').value = '';
     });
 
-    const leadForm = document.getElementById('lead-form');
-    if (leadForm) {
-        leadForm.addEventListener('submit', () => {
-            leadForm.reset();
-        });
-    }
-
     const alertEl = document.querySelector('.alert');
     if (alertEl) {
         setTimeout(() => {


### PR DESCRIPTION
## Summary
- avoid clearing form inputs during submission so edits can persist

## Testing
- `php -l leads.php`


------
https://chatgpt.com/codex/tasks/task_e_68bbdccc2e2c832a9c8c3c7c999a4bf0