### PR TITLE
Add prev/next icons to leads pagination

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1485,3 +1485,8 @@ h4.card-title.mb-0.flex-grow-1 {
     /* 👈 mobile pe thoda aur chhota */
   }
 }
+
+.pagination .page-item.active .page-link {
+  background-color: #004a44;
+  border-color: #004a44;
+}

--- a/leads.php
+++ b/leads.php
@@ -228,11 +228,21 @@ $leads = $conn->query(
                             <?php if ($totalPages > 1): ?>
                                 <nav aria-label="Lead pagination">
                                     <ul class="pagination justify-content-center mt-4">
+                                        <li class="page-item <?php echo ($page <= 1) ? 'disabled' : ''; ?>">
+                                            <a class="page-link" href="leads.php?page=<?php echo max(1, $page - 1); ?>" aria-label="Previous">
+                                                <i class="ri-arrow-left-s-line"></i>
+                                            </a>
+                                        </li>
                                         <?php for ($i = 1; $i <= $totalPages; $i++): ?>
                                             <li class="page-item <?php echo ($i == $page) ? 'active' : ''; ?>">
                                                 <a class="page-link" href="leads.php?page=<?php echo $i; ?>"><?php echo $i; ?></a>
                                             </li>
                                         <?php endfor; ?>
+                                        <li class="page-item <?php echo ($page >= $totalPages) ? 'disabled' : ''; ?>">
+                                            <a class="page-link" href="leads.php?page=<?php echo min($totalPages, $page + 1); ?>" aria-label="Next">
+                                                <i class="ri-arrow-right-s-line"></i>
+                                            </a>
+                                        </li>
                                     </ul>
                                 </nav>
                             <?php endif; ?>


### PR DESCRIPTION
## Summary
- use bootstrap-style pagination with prev/next icons in leads page
- highlight active pagination page with brand color

## Testing
- `php -l leads.php`


------
https://chatgpt.com/codex/tasks/task_e_68bbe75eda48832a97cbbaf3ec9d7402