### PR TITLE
Handle currency conversion failures

### DIFF
--- a/includes/common-footer.php
+++ b/includes/common-footer.php
@@ -244,8 +244,10 @@
 
         function updateCurrency(newCurrency) {
             currentCurrency = newCurrency;
-            applyConversion(1);
-            if (currentCurrency === baseCurrency) return;
+            if (currentCurrency === baseCurrency) {
+                applyConversion(1);
+                return;
+            }
             if (ratesCache[currentCurrency]) {
                 applyConversion(ratesCache[currentCurrency]);
                 return;
@@ -257,7 +259,10 @@
                     ratesCache[currentCurrency] = rate;
                     applyConversion(rate);
                 })
-                .catch(() => { });
+                .catch(() => {
+                    currentCurrency = baseCurrency;
+                    applyConversion(1);
+                });
         }
 
         const switcher = document.getElementById('currencySwitcher');


### PR DESCRIPTION
## Summary
- Avoid showing new currency symbol before numeric conversion
- Reset to base currency if rate lookup fails

## Testing
- `php -l includes/common-footer.php`


------
https://chatgpt.com/codex/tasks/task_e_68bbf27964c4832a9eb9946590f5f892