### PR TITLE
Add user profile image upload and display

### DIFF
--- a/channel_portal.sql
+++ b/channel_portal.sql
@@ -116,6 +116,7 @@ CREATE TABLE `users` (
   `email` varchar(100) NOT NULL,
   `password` varchar(255) NOT NULL,
   `role` enum('Admin','Manager','Channel Partner') NOT NULL,
+  `profile_image` varchar(255) DEFAULT NULL,
   `created_at` timestamp NOT NULL DEFAULT current_timestamp(),
   `last_active` timestamp NULL DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
@@ -124,10 +125,10 @@ CREATE TABLE `users` (
 -- Dumping data for table `users`
 --
 
-INSERT INTO `users` (`id`, `name`, `username`, `email`, `password`, `role`, `created_at`, `last_active`) VALUES
-(1, 'Rehman Shaoib', 'rehmanshoaib', 'shoaib@reliantsurveyors.com', '$2y$10$0zpNlMd46dES26IFRynwXebMeIdUO3JXCy.R96yPIJ9yqGP16tbkq', 'Admin', '2025-08-18 06:44:43', NULL),
-(2, 'Dev Aabhroy', 'dev', 'dev@gmail.com', '$2y$10$5/Qxeccnas51So70xhHhGOHq1e6CoBfhThb..kEI2W4c9B45Y9IOa', 'Admin', '2025-08-22 05:14:43', NULL),
-(3, 'Shoaib Akhtar', 'shoaibakhtar', 'shoaib@gmail.com', '$2y$10$FKoW7BU6sBHsQ6I5B3MVtuCZKp4z/ODfgcsmnhfnbgroOqNGTmdgC', 'Admin', '2025-08-22 10:09:35', NULL);
+INSERT INTO `users` (`id`, `name`, `username`, `email`, `password`, `role`, `profile_image`, `created_at`, `last_active`) VALUES
+(1, 'Rehman Shaoib', 'rehmanshoaib', 'shoaib@reliantsurveyors.com', '$2y$10$0zpNlMd46dES26IFRynwXebMeIdUO3JXCy.R96yPIJ9yqGP16tbkq', 'Admin', '', '2025-08-18 06:44:43', NULL),
+(2, 'Dev Aabhroy', 'dev', 'dev@gmail.com', '$2y$10$5/Qxeccnas51So70xhHhGOHq1e6CoBfhThb..kEI2W4c9B45Y9IOa', 'Admin', '', '2025-08-22 05:14:43', NULL),
+(3, 'Shoaib Akhtar', 'shoaibakhtar', 'shoaib@gmail.com', '$2y$10$FKoW7BU6sBHsQ6I5B3MVtuCZKp4z/ODfgcsmnhfnbgroOqNGTmdgC', 'Admin', '', '2025-08-22 10:09:35', NULL);
 
 --
 -- Indexes for dumped tables

--- a/edit_user.php
+++ b/edit_user.php
@@ -8,9 +8,29 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     $email    = $_POST['email'];
     $role     = $_POST['role'];
 
-    $sql = "UPDATE users SET name=?, username=?, email=?, role=? WHERE id=?";
+    $profileSql = '';
+    $params = [$name, $username, $email, $role];
+    $types = "ssss";
+    if (!empty($_FILES['profile_image']['name']) && $_FILES['profile_image']['error'] === UPLOAD_ERR_OK) {
+        $uploadDir = 'uploads/users/';
+        if (!is_dir($uploadDir)) {
+            mkdir($uploadDir, 0777, true);
+        }
+        $tmp = $_FILES['profile_image']['tmp_name'];
+        $fileName = time() . '_' . basename($_FILES['profile_image']['name']);
+        $dest = $uploadDir . $fileName;
+        if (move_uploaded_file($tmp, $dest)) {
+            $profileSql = ", profile_image=?";
+            $params[] = $dest;
+            $types .= "s";
+        }
+    }
+    $params[] = $id;
+    $types .= "i";
+
+    $sql = "UPDATE users SET name=?, username=?, email=?, role=?$profileSql WHERE id=?";
     $stmt = $conn->prepare($sql);
-    $stmt->bind_param("ssssi", $name, $username, $email, $role, $id);
+    $stmt->bind_param($types, ...$params);
 
     if ($stmt->execute()) {
         echo "success";

--- a/register_user.php
+++ b/register_user.php
@@ -18,9 +18,23 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
         exit;
     }
 
+    $profileImage = '';
+    if (!empty($_FILES['profile_image']['name']) && $_FILES['profile_image']['error'] === UPLOAD_ERR_OK) {
+        $uploadDir = 'uploads/users/';
+        if (!is_dir($uploadDir)) {
+            mkdir($uploadDir, 0777, true);
+        }
+        $tmpName = $_FILES['profile_image']['tmp_name'];
+        $fileName = time() . '_' . basename($_FILES['profile_image']['name']);
+        $destPath = $uploadDir . $fileName;
+        if (move_uploaded_file($tmpName, $destPath)) {
+            $profileImage = $destPath;
+        }
+    }
+
     $hashed_password = password_hash($password, PASSWORD_BCRYPT);
 
-    $sql = "INSERT INTO users (name, username, email, password, role) VALUES (?, ?, ?, ?, ?)";
+    $sql = "INSERT INTO users (name, username, email, password, role, profile_image) VALUES (?, ?, ?, ?, ?, ?)";
     $stmt = $conn->prepare($sql);
 
     if (!$stmt) {
@@ -28,7 +42,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
         exit;
     }
 
-    $stmt->bind_param("sssss", $name, $username, $email, $hashed_password, $role);
+    $stmt->bind_param("ssssss", $name, $username, $email, $hashed_password, $role, $profileImage);
 
     if ($stmt->execute()) {
         echo json_encode(["status" => "success", "message" => "User registered successfully!"]);

--- a/users.php
+++ b/users.php
@@ -121,63 +121,72 @@
 
                         <!-- ✅ Backend Connected Form -->
                      <form id="registerForm" class="tablelist-form" action="register_user.php" method="POST"
-                            autocomplete="off">
+                            enctype="multipart/form-data" autocomplete="off">
                              <input type="hidden" id="user-id" name="id" />
                              <div class="modal-body">
-                                <!-- Name -->
-                                <div class="mb-3">
-                                    <label for="name-field" class="form-label">Name</label>
-                                    <input type="text" id="name-field" name="name" class="form-control"
-                                        placeholder="Enter Full Name" required />
-                                </div>
-
-                                <!-- Username -->
-                                <div class="mb-3">
-                                    <label for="username-field" class="form-label">Username</label>
-                                    <input type="text" id="username-field" name="username" class="form-control"
-                                        placeholder="Enter Username" required />
-                                </div>
-
-                                <!-- Email -->
-                                <div class="mb-3">
-                                    <label for="email-field" class="form-label">Email</label>
-                                    <input type="email" id="email-field" name="email" class="form-control"
-                                        placeholder="Enter Email" required />
-                                </div>
-
-                                 <!-- Password -->
-                                 <div class="mb-3 position-relative toggleBtn" id="password-group">
-                                    <label for="password-field" class="form-label">Password</label>
-                                    <input type="password" id="password-field" name="password" class="form-control"
-                                        placeholder="Enter Password" required />
-                                    <button type="button"
-                                        class="btn btn-sm btn-outline-secondary position-absolute top-50 end-0 translate-middle-y me-2"
-                                        onclick="togglePassword('password-field', this)">
-                                        👁
-                                    </button>
-                                </div>
-
-                                 <!-- Confirm Password -->
-                                 <div class="mb-3 position-relative toggleBtn" id="confirm-password-group">
-                                    <label for="confirm-password-field" class="form-label">Confirm Password</label>
-                                    <input type="password" id="confirm-password-field" name="confirm_password"
-                                        class="form-control" placeholder="Confirm Password" required />
-                                    <button type="button"
-                                        class="btn btn-sm btn-outline-secondary position-absolute top-50 end-0 translate-middle-y me-2"
-                                        onclick="togglePassword('confirm-password-field', this)">
-                                        👁
-                                    </button>
-                                </div>
-
-                                <!-- Role -->
-                                <div class="mb-3">
-                                    <label for="role-field" class="form-label">Role</label>
-                                    <select class="form-control form-select" name="role" id="role-field" required>
-                                        <option value="">Select Role</option>
-                                        <option value="Admin">Admin</option>
-                                        <option value="Manager">Manager</option>
-                                        <option value="Channel Partner">Channel Partner</option>
-                                    </select>
+                                <div class="row g-3">
+                                    <div class="col-lg-6">
+                                        <div class="mb-3">
+                                            <label for="name-field" class="form-label">Name</label>
+                                            <input type="text" id="name-field" name="name" class="form-control"
+                                                placeholder="Enter Full Name" required />
+                                        </div>
+                                    </div>
+                                    <div class="col-lg-6">
+                                        <div class="mb-3">
+                                            <label for="username-field" class="form-label">Username</label>
+                                            <input type="text" id="username-field" name="username" class="form-control"
+                                                placeholder="Enter Username" required />
+                                        </div>
+                                    </div>
+                                    <div class="col-lg-6">
+                                        <div class="mb-3">
+                                            <label for="email-field" class="form-label">Email</label>
+                                            <input type="email" id="email-field" name="email" class="form-control"
+                                                placeholder="Enter Email" required />
+                                        </div>
+                                    </div>
+                                    <div class="col-lg-6">
+                                        <div class="mb-3">
+                                            <label for="role-field" class="form-label">Role</label>
+                                            <select class="form-control form-select" name="role" id="role-field" required>
+                                                <option value="">Select Role</option>
+                                                <option value="Admin">Admin</option>
+                                                <option value="Manager">Manager</option>
+                                                <option value="Channel Partner">Channel Partner</option>
+                                            </select>
+                                        </div>
+                                    </div>
+                                    <div class="col-lg-6">
+                                        <div class="mb-3 position-relative toggleBtn" id="password-group">
+                                            <label for="password-field" class="form-label">Password</label>
+                                            <input type="password" id="password-field" name="password" class="form-control"
+                                                placeholder="Enter Password" required />
+                                            <button type="button"
+                                                class="btn btn-sm btn-outline-secondary position-absolute top-50 end-0 translate-middle-y me-2"
+                                                onclick="togglePassword('password-field', this)">
+                                                👁
+                                            </button>
+                                        </div>
+                                    </div>
+                                    <div class="col-lg-6">
+                                        <div class="mb-3 position-relative toggleBtn" id="confirm-password-group">
+                                            <label for="confirm-password-field" class="form-label">Confirm Password</label>
+                                            <input type="password" id="confirm-password-field" name="confirm_password"
+                                                class="form-control" placeholder="Confirm Password" required />
+                                            <button type="button"
+                                                class="btn btn-sm btn-outline-secondary position-absolute top-50 end-0 translate-middle-y me-2"
+                                                onclick="togglePassword('confirm-password-field', this)">
+                                                👁
+                                            </button>
+                                        </div>
+                                    </div>
+                                    <div class="col-lg-6">
+                                        <div class="mb-3">
+                                            <label for="profile-image" class="form-label">Profile Image</label>
+                                            <input type="file" id="profile-image" name="profile_image" class="form-control" accept="image/*" />
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
 

--- a/users_list.php
+++ b/users_list.php
@@ -5,25 +5,26 @@ $result = $conn->query($sql);
 
 if ($result->num_rows > 0) {
     while ($row = $result->fetch_assoc()) {
+        $img = !empty($row['profile_image']) ? $row['profile_image'] : 'assets/images/users/avatar-1.jpg';
         echo "<tr>
 
                 <td class='id'>#{$row['id']}</td>
-                <td class='name'>{$row['name']}</td>
+                <td class='name'><div class='d-flex align-items-center'><img src='{$img}' alt='' class='rounded-circle avatar-xs me-2'> {$row['name']}</div></td>
                 <td class='username'>{$row['username']}</td>
                 <td class='email'>{$row['email']}</td>
                 <td class='role'><span class='badge bg-success-subtle text-success text-uppercase'>{$row['role']}</span></td>
                 <td>
                     <div class='d-flex gap-2'>
                         <div class='edit'>
-                            <button class='btn btn-sm btn-success edit-item-btn' 
-                                    data-id='{$row['id']}' 
-                                    data-bs-toggle='modal' 
+                            <button class='btn btn-sm btn-success edit-item-btn'
+                                    data-id='{$row['id']}'
+                                    data-bs-toggle='modal'
                                     data-bs-target='#showModal'>Edit</button>
                         </div>
                         <div class='remove'>
-                            <button class='btn btn-sm btn-danger remove-item-btn' 
-                                    data-id='{$row['id']}' 
-                                    data-bs-toggle='modal' 
+                            <button class='btn btn-sm btn-danger remove-item-btn'
+                                    data-id='{$row['id']}'
+                                    data-bs-toggle='modal'
                                     data-bs-target='#deleteRecordModal'>Remove</button>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- Use Bootstrap grid with `col-lg-6` in user registration modal and add profile image input
- Store uploaded profile images on registration and allow optional update when editing
- Show profile avatars alongside user names and extend DB schema with `profile_image` column

## Testing
- `php -l users.php && php -l register_user.php && php -l edit_user.php && php -l users_list.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc110f93e4832aa1a153821c773cb7