### PR TITLE
Fix edit lead modal when message field absent

### DIFF
--- a/leads.php
+++ b/leads.php
@@ -330,7 +330,10 @@ $leads = $conn->query(
             document.getElementById('lead-phone').value = this.dataset.phone;
             document.getElementById('lead-property').value = this.dataset.property;
             document.getElementById('lead-status').value = this.dataset.status;
-            document.getElementById('lead-message').value = this.dataset.message;
+            const messageEl = document.getElementById('lead-message');
+            if (messageEl) {
+                messageEl.value = this.dataset.message;
+            }
             new bootstrap.Modal(modalEl).show();
         });
     });


### PR DESCRIPTION
## Summary
- Prevent JS error when opening edit lead modal without message field

## Testing
- `php -l leads.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc1ac52160832abb9c45ffd23e6232