### PR TITLE
Display selected user details in chat header

### DIFF
--- a/assets/js/chat.js
+++ b/assets/js/chat.js
@@ -3,14 +3,20 @@ document.addEventListener("DOMContentLoaded", function () {
   const chatBox = document.getElementById("chatBox");
   const messageInput = document.getElementById("messageInput");
   const sendBtn = document.getElementById("sendBtn");
+  const chatUserImage = document.getElementById("chatUserImage");
+  const chatUserName = document.getElementById("chatUserName");
+  const chatUserStatus = document.getElementById("chatUserStatus");
   let currentUser = null;
+  let usersCache = {};
 
   function loadUsers() {
     fetch("fetch_users.php")
       .then((res) => res.json())
       .then((users) => {
         userList.innerHTML = "";
+        usersCache = {};
         users.forEach((u) => {
+          usersCache[u.id] = u;
           const li = document.createElement("li");
           li.className =
             "list-group-item d-flex justify-content-between align-items-center";
@@ -22,10 +28,14 @@ document.addEventListener("DOMContentLoaded", function () {
           li.appendChild(badge);
           li.onclick = () => {
             currentUser = u.id;
+            setChatHeader(u);
             loadMessages();
           };
           userList.appendChild(li);
         });
+        if (currentUser && usersCache[currentUser]) {
+          setChatHeader(usersCache[currentUser]);
+        }
       });
   }
 
@@ -85,6 +95,19 @@ document.addEventListener("DOMContentLoaded", function () {
 
   function updateStatus() {
     fetch("update_last_active.php");
+  }
+
+  function setChatHeader(u) {
+    chatUserImage.src = u.profile_image;
+    chatUserName.textContent = u.name;
+    if (u.online) {
+      chatUserStatus.textContent = "Online";
+    } else if (u.last_active) {
+      const d = new Date(u.last_active);
+      chatUserStatus.textContent = "Last seen " + d.toLocaleString();
+    } else {
+      chatUserStatus.textContent = "Offline";
+    }
   }
 
   setInterval(() => {

--- a/chat.php
+++ b/chat.php
@@ -46,20 +46,18 @@ include 'config.php';
                 <div class="col-md-8 d-flex flex-column">
                     <div class="chat-header">
                         <div class="d-flex align-items-center">
-                            <img src="https://i.pravatar.cc/40?img=4" alt="">
+                            <img id="chatUserImage" src="assets/images/users/avatar-1.jpg" alt="" class="rounded-circle">
                             <div>
-                                <div><strong>Theron Trump</strong></div>
-                                <small>Last seen 10:30pm</small>
+                                <div><strong id="chatUserName">Select a user</strong></div>
+                                <small id="chatUserStatus"></small>
                             </div>
                         </div>
                         <div class="d-flex align-items-center gap-2">
                             <div class="header-icons">
                                 <img src="assets/icons/telephone.png" />
-
                             </div>
                             <div class="header-icons">
                                 <img src="assets/icons/video-call.png" />
-
                             </div>
                         </div>
                     </div>

--- a/fetch_users.php
+++ b/fetch_users.php
@@ -3,14 +3,21 @@ include 'includes/auth.php';
 include 'config.php';
 
 $current = $_SESSION['user_id'];
-$res = $conn->query("SELECT id, name, last_active FROM users WHERE id <> $current");
+$res = $conn->query("SELECT id, name, profile_image, last_active FROM users WHERE id <> $current");
 $users = [];
 while ($row = $res->fetch_assoc()) {
     $online = false;
     if ($row['last_active']) {
         $online = (strtotime($row['last_active']) > time() - 300); // 5 minutes
     }
-    $users[] = ['id' => $row['id'], 'name' => $row['name'], 'online' => $online];
+    $img = !empty($row['profile_image']) ? $row['profile_image'] : 'assets/images/users/avatar-1.jpg';
+    $users[] = [
+        'id' => $row['id'],
+        'name' => $row['name'],
+        'online' => $online,
+        'last_active' => $row['last_active'],
+        'profile_image' => $img
+    ];
 }
 header('Content-Type: application/json');
 echo json_encode($users);


### PR DESCRIPTION
## Summary
- Dynamically populate chat header with selected user's avatar, name and status
- Provide user profile image and last active timestamp in user list API
- Update chat UI logic to cache users and refresh header information

## Testing
- `php -l chat.php`
- `php -l fetch_users.php`
- `node --check assets/js/chat.js`


------
https://chatgpt.com/codex/tasks/task_e_68bc230eaeb0832ab55733dc0fc0962d